### PR TITLE
Update travel_calculator to not fail when no encounters are loaded

### DIFF
--- a/swim/scripts/swim_modules/travel_calculator.js
+++ b/swim/scripts/swim_modules/travel_calculator.js
@@ -73,7 +73,7 @@ export async function travel_calculator() {
                     const method = html.find('[name="method"]').val();
                     let generateEncounters = false
                     if (enemiesTable && obstaclesTable && strangersTable && treasuresTable) {
-                        generateEncounters = html.find('#generateEncounters')[0].checked;
+                        generateEncounters = html.find('#generateEncounters')[0]?.checked;
                     }
                     if (!distance || distance <= 0) {
                         return ui.notifications.error(game.i18n.localize("SWIM.notification-invalidTravelDistance"));


### PR DESCRIPTION
Travel Encounters macro currently fails if there are no encounters loaded (niche situation, but nice for it to either gracefully return a message or just continue with the macro on undefined, I chose the latter option since it seems intentional to not have encounters loaded and not choose to run encounters).